### PR TITLE
Ability to submit forms

### DIFF
--- a/src/Behat/SahiClient/Accessor/AbstractAccessor.php
+++ b/src/Behat/SahiClient/Accessor/AbstractAccessor.php
@@ -349,6 +349,16 @@ abstract class AbstractAccessor
     }
 
     /**
+     * Return true if checkbox/radio checked.
+     *
+     * @return  boolean
+     */
+    public function submitForm()
+    {
+        $this->con->evaluateJavascript(sprintf('%s.submit()', $this->getAccessor()));
+    }
+
+    /**
      * Return accessor string.
      *
      * @return  string

--- a/tests/Behat/SahiClient/Accessor/SharedActionsTest.php
+++ b/tests/Behat/SahiClient/Accessor/SharedActionsTest.php
@@ -200,4 +200,15 @@ class SharedActionsTest extends AbstractAccessorTest
             array(), true
         );
     }
+
+    /**
+    * @dataProvider    getAccessors
+    */
+   public function testSubmitForm(Accessor\AbstractAccessor $accessor, $selector)
+   {
+       $this->assertActionJavascript(
+           $selector . '.submit()', null,
+           array($accessor, 'submitForm')
+       );
+   }
 }


### PR DESCRIPTION
Adds `submit` method for `NodeElement` matching. Implementation of https://github.com/Behat/Mink/issues/336.
