### PR TITLE
Return actual attribute value where needed.

### DIFF
--- a/src/Behat/SahiClient/Accessor/AbstractAccessor.php
+++ b/src/Behat/SahiClient/Accessor/AbstractAccessor.php
@@ -297,7 +297,14 @@ abstract class AbstractAccessor
      */
     public function getAttr($attr)
     {
-        return $this->con->evaluateJavascript(sprintf('%s.getAttribute("%s")', $this->getAccessor(), $attr));
+        $attributeValue = $this->con->evaluateJavascript(sprintf('%s.getAttribute("%s")', $this->getAccessor(), $attr));
+
+        if ($attributeValue === false) {
+            // see https://github.com/kriswallsmith/Buzz/pull/138 bug
+            return '';
+        }
+
+        return $attributeValue;
     }
 
     /**

--- a/tests/Behat/SahiClient/Accessor/SharedActionsTest.php
+++ b/tests/Behat/SahiClient/Accessor/SharedActionsTest.php
@@ -161,6 +161,23 @@ class SharedActionsTest extends AbstractAccessorTest
     /**
      * @dataProvider    getAccessors
      */
+    public function testGetEmptyAttr(Accessor\AbstractAccessor $accessor, $selector)
+    {
+        $connection = $this->getConnectionMock();
+        $connection
+            ->expects($this->once())
+            ->method('evaluateJavascript')
+            ->with($selector . '.getAttribute("test-attr")')
+            ->will($this->returnValue(false));
+
+        $accessor->setConnection($connection);
+
+        $this->assertEquals('', $accessor->getAttr('test-attr'));
+    }
+
+    /**
+     * @dataProvider    getAccessors
+     */
     public function testGetText(Accessor\AbstractAccessor $accessor, $selector)
     {
         $this->assertActionJavascript(


### PR DESCRIPTION
Due https://github.com/kriswallsmith/Buzz/pull/138 bug in used library we're getting a `false` instead of an `empty string` for empty attribute values. This is the workaround code to get 100% consistent attribute values until  `kriswallsmith/buzz` has release a fix.

Fixes #11.
Related to https://github.com/Behat/Mink/issues/389.
