### PR TITLE
Fixing incorrect `wait` method return value type

### DIFF
--- a/src/Behat/SahiClient/Client.php
+++ b/src/Behat/SahiClient/Client.php
@@ -177,7 +177,7 @@ class Client
             }
         }
 
-        return $conditionResult;
+        return 'true' === $conditionResult;
     }
 
     /**

--- a/tests/Behat/SahiClient/ClientTest.php
+++ b/tests/Behat/SahiClient/ClientTest.php
@@ -65,7 +65,7 @@ class ClientTest extends AbstractConnectionTest
             ->expects($this->any())
             ->method('evaluateJavascript')
             ->with('found-element')
-            ->will($this->returnValue(true));
+            ->will($this->returnValue('true'));
 
         $this->assertTrue($this->api->wait(500, 'found-element'));
     }
@@ -84,7 +84,7 @@ class ClientTest extends AbstractConnectionTest
             ->expects($this->any())
             ->method('evaluateJavascript')
             ->with('not-found-element')
-            ->will($this->returnValue(false));
+            ->will($this->returnValue('false'));
 
         $this->assertFalse($this->api->wait(500, 'not-found-element'));
     }


### PR DESCRIPTION
Due bug in tests for `wait` method the bug in method itself wasn't catched. Method `wait` was returning `true` and `false` as string instead of boolean causing testing in `MinkSahiDriver` to fail with all `SahiClient` tests passing.
