### PR TITLE
Improved the script evaluation to preserve the type

### DIFF
--- a/src/Behat/SahiClient/Accessor/AbstractAccessor.php
+++ b/src/Behat/SahiClient/Accessor/AbstractAccessor.php
@@ -71,7 +71,7 @@ abstract class AbstractAccessor
      */
     public function isChecked()
     {
-        return "true" === $this->con->evaluateJavascript(sprintf('%s.checked', $this->getAccessor()));
+        return $this->con->evaluateJavascript(sprintf('%s.checked', $this->getAccessor()));
     }
 
     /**
@@ -89,7 +89,7 @@ abstract class AbstractAccessor
      */
     public function isSelected()
     {
-        return "true" === $this->con->evaluateJavascript(sprintf('%s.selected', $this->getAccessor()));
+        return $this->con->evaluateJavascript(sprintf('%s.selected', $this->getAccessor()));
     }
 
     /**
@@ -353,7 +353,7 @@ abstract class AbstractAccessor
      */
     public function isVisible()
     {
-        return 'true' === $this->con->evaluateJavascript(sprintf('_sahi._isVisible(%s)', $this->getAccessor()));
+        return $this->con->evaluateJavascript(sprintf('_sahi._isVisible(%s)', $this->getAccessor()));
     }
 
     /**
@@ -363,7 +363,7 @@ abstract class AbstractAccessor
      */
     public function isExists()
     {
-        return 'true' === $this->con->evaluateJavascript(sprintf('_sahi._exists(%s)', $this->getAccessor()));
+        return $this->con->evaluateJavascript(sprintf('_sahi._exists(%s)', $this->getAccessor()));
     }
 
     /**

--- a/src/Behat/SahiClient/Client.php
+++ b/src/Behat/SahiClient/Client.php
@@ -165,7 +165,7 @@ class Client
     public function wait($time, $condition)
     {
         $conditionResult = false;
-        while ($time > 0 && 'true' !== $conditionResult) {
+        while ($time > 0 && true !== $conditionResult) {
             usleep(100);
             $time -= 100;
 
@@ -177,7 +177,7 @@ class Client
             }
         }
 
-        return 'true' === $conditionResult;
+        return (boolean) $conditionResult;
     }
 
     /**

--- a/src/Behat/SahiClient/Connection.php
+++ b/src/Behat/SahiClient/Connection.php
@@ -229,19 +229,19 @@ class Connection
      * @param string  $expression JS expression
      * @param integer $limit      time limit (value of 10 === 1 second)
      *
-     * @return string|null
+     * @return mixed
      */
     public function evaluateJavascript($expression, $limit = null)
     {
         $key = '___lastValue___' . uniqid();
         $this->executeStep(
-            sprintf("_sahi.setServerVarPlain(%s, %s)", json_encode($key), $expression),
+            sprintf("_sahi.setServerVarPlain(%s, JSON.stringify(%s))", json_encode($key), $expression),
             $limit
         );
 
         $resp = $this->executeCommand('getVariable', array('key' => $key));
 
-        return 'null' === $resp ? null : $resp;
+        return json_decode($resp, true);
     }
 
     /**

--- a/tests/Behat/SahiClient/AbstractConnectionTest.php
+++ b/tests/Behat/SahiClient/AbstractConnectionTest.php
@@ -39,7 +39,7 @@ abstract class AbstractConnectionTest extends \PHPUnit_Framework_TestCase
         call_user_func_array($command, $arguments);
     }
 
-    protected function assertActionJavascript($expected, $return, array $command, array $arguments = array(), $trueReturn = null)
+    protected function assertActionJavascript($expected, $return, array $command, array $arguments = array())
     {
         $connection = $this->getConnectionMock();
         $connection
@@ -50,6 +50,6 @@ abstract class AbstractConnectionTest extends \PHPUnit_Framework_TestCase
 
         $command[0]->setConnection($connection);
 
-        $this->assertEquals($trueReturn ?: $return, call_user_func_array($command, $arguments));
+        $this->assertEquals($return, call_user_func_array($command, $arguments));
     }
 }

--- a/tests/Behat/SahiClient/Accessor/FormAccessorTest.php
+++ b/tests/Behat/SahiClient/Accessor/FormAccessorTest.php
@@ -31,10 +31,9 @@ class FormAccessorTest extends AbstractAccessorTest
 
         $this->assertActionJavascript(
             '_sahi._option("Man").selected',
-            'true',
+            true,
             array($accessor, 'isSelected'),
-            array(),
-            true
+            array()
         );
 
         $this->assertRelations($accessor, '_sahi._option("Man", ');
@@ -49,10 +48,9 @@ class FormAccessorTest extends AbstractAccessorTest
         $this->assertActionStep('_sahi._check(_sahi._radio("id"))', array($accessor, 'check'));
         $this->assertActionJavascript(
             '_sahi._radio("id").checked',
-            'true',
+            true,
             array($accessor, 'isChecked'),
-            array(),
-            true
+            array()
         );
         $this->assertRelations($accessor, '_sahi._radio("id", ');
     }
@@ -67,10 +65,9 @@ class FormAccessorTest extends AbstractAccessorTest
         $this->assertActionStep('_sahi._uncheck(_sahi._checkbox("id"))', array($accessor, 'uncheck'));
         $this->assertActionJavascript(
             '_sahi._checkbox("id").checked',
-            'true',
+            true,
             array($accessor, 'isChecked'),
-            array(),
-            true
+            array()
         );
         $this->assertRelations($accessor, '_sahi._checkbox("id", ');
     }

--- a/tests/Behat/SahiClient/Accessor/SharedActionsTest.php
+++ b/tests/Behat/SahiClient/Accessor/SharedActionsTest.php
@@ -152,7 +152,7 @@ class SharedActionsTest extends AbstractAccessorTest
     {
         $this->assertActionJavascript(
             $selector . '.getAttribute("checked")',
-            'true',
+            'checked',
             array($accessor, 'getAttr'),
             array('checked')
         );
@@ -202,10 +202,9 @@ class SharedActionsTest extends AbstractAccessorTest
     {
         $this->assertActionJavascript(
             '_sahi._isVisible(' . $selector . ')',
-            'true',
+            true,
             array($accessor, 'isVisible'),
-            array(),
-            true
+            array()
         );
     }
 
@@ -216,10 +215,9 @@ class SharedActionsTest extends AbstractAccessorTest
     {
         $this->assertActionJavascript(
             '_sahi._exists(' . $selector . ')',
-            'true',
+            true,
             array($accessor, 'isExists'),
-            array(),
-            true
+            array()
         );
     }
 

--- a/tests/Behat/SahiClient/ClientTest.php
+++ b/tests/Behat/SahiClient/ClientTest.php
@@ -214,7 +214,7 @@ class ClientTest extends AbstractConnectionTest
             ->expects($this->any())
             ->method('evaluateJavascript')
             ->with('found-element')
-            ->will($this->returnValue('true'));
+            ->will($this->returnValue(true));
 
         $this->assertTrue($this->api->wait(500, 'found-element'));
     }
@@ -230,7 +230,7 @@ class ClientTest extends AbstractConnectionTest
             ->expects($this->any())
             ->method('evaluateJavascript')
             ->with('not-found-element')
-            ->will($this->returnValue('false'));
+            ->will($this->returnValue(false));
 
         $this->assertFalse($this->api->wait(500, 'not-found-element'));
     }


### PR DESCRIPTION
This will fix the remaining issues in https://github.com/Behat/MinkSahiDriver/pull/34 by returning the proper PHP type in `Connection::evaluateScript` rather than always returning a string
